### PR TITLE
Revamp development tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ To run the server and the client:
 ```
 yarn dev
 ```
-The script above will run the express server and webpack in watch mode at the sime time.
+The script above will run the express server and webpack in watch mode at the same time.
 You can then access the app `localhost:3000`
 
 If you want to run using `react-hot-loader` you will have to run `yarn dev-hot` and access the app at `localhost:8080`. This serves the app from a custom server of `webpack-dev-server`, so if you are developing some backend code you might want to run the server without the `hot` mode.

--- a/README.md
+++ b/README.md
@@ -9,18 +9,19 @@ For dependencies:
 yarn install
 ```
 
-To run the server and the client: 
+To run the server and the client:
 ```
 yarn dev
 ```
-The script above will run the express server and the webpack-dev-server at the sime time. 
-The server is at `localhost:3000` but the client code is actually served at `localhost:8080`. 
-Use the second address to have access to hot module reloading.
+The script above will run the express server and webpack in watch mode at the sime time.
+You can then access the app `localhost:3000`
+
+If you want to run using `react-hot-loader` you will have to run `yarn dev-hot` and access the app at `localhost:8080`. This serves the app from a custom server of `webpack-dev-server`, so if you are developing some backend code you might want to run the server without the `hot` mode.
 
 Some considerations:
 * CORS is enabled in development and disabled in production, for safety. During development we need cors to access the api from a
 different host.
-* The client has hot reloading via webpack's HMR and React Hot Loader. The server doesn't have hot reloading, but we use nodemon to
+* The client has hot reloading via webpack's HMR (when using `yarn dev-hot`) and React Hot Loader. The server doesn't have hot reloading, but we use nodemon to
 restart the server when we change code.
 
 To test the app run:

--- a/package.json
+++ b/package.json
@@ -12,9 +12,11 @@
   "scripts": {
     "heroku-postbuild": "webpack --mode production",
     "start": "node src/backend/index.js",
-    "dev-server": "NR_PROCESSES=1 nodemon src/backend/index.js",
-    "dev-client": "webpack-dev-server --mode development --hot",
+    "dev-server": "NR_PROCESSES=1 nodemon --ignore src/frontend src/backend/index.js",
+    "dev-client": "webpack --watch --mode development",
+    "dev-client-hot": "webpack-dev-server --mode development --hot",
     "dev": "npm-run-all --parallel dev-server dev-client",
+    "dev-hot": "npm-run-all --parallel dev-server dev-client-hot",
     "lint": "eslint src test",
     "lint-fix": "eslint --fix src test",
     "lint-styles": "stylelint frontend/components/**/*.css",

--- a/src/frontend/components/Firefighter/index.js
+++ b/src/frontend/components/Firefighter/index.js
@@ -4,7 +4,7 @@ import PropTypes from "prop-types";
 import "./index.css";
 
 const label = {
-  active: "disponível",
+  active: "Disponível",
   inactive: "",
   busy: "Serviço"
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1242,6 +1242,21 @@ body-parser@1.18.2:
     raw-body "2.3.2"
     type-is "~1.6.15"
 
+body-parser@^1.18.3:
+  version "1.18.3"
+  resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.18.3.tgz#5b292198ffdd553b3a0f20ded0592b956955c8b4"
+  dependencies:
+    bytes "3.0.0"
+    content-type "~1.0.4"
+    debug "2.6.9"
+    depd "~1.1.2"
+    http-errors "~1.6.3"
+    iconv-lite "0.4.23"
+    on-finished "~2.3.0"
+    qs "6.5.2"
+    raw-body "2.3.3"
+    type-is "~1.6.16"
+
 bonjour@^3.5.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/bonjour/-/bonjour-3.5.0.tgz#8e890a183d8ee9a2393b3844c691a42bcf7bc9f5"
@@ -3656,7 +3671,7 @@ http-errors@1.6.2:
     setprototypeof "1.0.3"
     statuses ">= 1.3.1 < 2"
 
-http-errors@~1.6.2:
+http-errors@1.6.3, http-errors@~1.6.2, http-errors@~1.6.3:
   version "1.6.3"
   resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.6.3.tgz#8b55680bb4be283a0b5bf4ea2e38580be1d9320d"
   dependencies:
@@ -3698,7 +3713,7 @@ iconv-lite@0.4.19:
   version "0.4.19"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.19.tgz#f7468f60135f5e5dad3399c0a81be9a1603a082b"
 
-iconv-lite@^0.4.17, iconv-lite@^0.4.22, iconv-lite@^0.4.4, iconv-lite@~0.4.13:
+iconv-lite@0.4.23, iconv-lite@^0.4.17, iconv-lite@^0.4.22, iconv-lite@^0.4.4, iconv-lite@~0.4.13:
   version "0.4.23"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.23.tgz#297871f63be507adcfbfca715d0cd0eed84e9a63"
   dependencies:
@@ -6335,7 +6350,7 @@ qs@6.5.1:
   version "6.5.1"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.1.tgz#349cdf6eef89ec45c12d7d5eb3fc0c870343a6d8"
 
-qs@^6.5.1:
+qs@6.5.2, qs@^6.5.1:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
 
@@ -6394,6 +6409,15 @@ raw-body@2.3.2:
     bytes "3.0.0"
     http-errors "1.6.2"
     iconv-lite "0.4.19"
+    unpipe "1.0.0"
+
+raw-body@2.3.3:
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/raw-body/-/raw-body-2.3.3.tgz#1b324ece6b5706e153855bc1148c65bb7f6ea0c3"
+  dependencies:
+    bytes "3.0.0"
+    http-errors "1.6.3"
+    iconv-lite "0.4.23"
     unpipe "1.0.0"
 
 rc@^1.0.1, rc@^1.1.6, rc@^1.2.7:


### PR DESCRIPTION
Creates two tasks, one `yarn dev` to develop at localhost:3000 without hot reloading and with the JS bundle being served through our server; and one `yarn dev-hot` using webpack-dev-server with hot reload.