### PR TITLE
Update duty to allow multiple state

### DIFF
--- a/scripts/seed.js
+++ b/scripts/seed.js
@@ -51,13 +51,13 @@ const firefightersNumbers = [
 const firefightersList = firefightersNumbers.map(number => ({
   name: number.toString(),
   status: "inactive",
-  isOnDuty: false
+  dutyType: "none"
 }));
 
 const firefightersCommand = [
-  { name: "Cmdt", status: "inactive", isOnDuty: false },
-  { name: "2º Cmdt", status: "inactive", isOnDuty: false },
-  { name: "Adj", status: "inactive", isOnDuty: false }
+  { name: "Cmdt", status: "inactive", dutyType: "none" },
+  { name: "2º Cmdt", status: "inactive", dutyType: "none" },
+  { name: "Adj", status: "inactive", dutyType: "none" }
 ];
 
 (async () => {

--- a/src/backend/models/firefighter.js
+++ b/src/backend/models/firefighter.js
@@ -5,7 +5,7 @@ const FirefighterSchema = new mongoose.Schema(
     name: String,
     ff_id: String,
     status: String,
-    isOnDuty: Boolean
+    dutyType: String
   },
   { timestamps: true }
 );

--- a/src/backend/repo/historyCalculator.js
+++ b/src/backend/repo/historyCalculator.js
@@ -5,20 +5,12 @@ function dateDiff(before, after) {
   return Math.floor(diff / 1000 / 60);
 }
 
-function getElapsedTimesOfState(
-  eventState,
-  timeElapsed,
-  { onDutyTime, activeTime }
-) {
-  if (eventState.isOnDuty) {
-    return { onDutyTime: onDutyTime + timeElapsed, activeTime };
-  }
-
+function getElapsedTimesOfState(eventState, timeElapsed, { activeTime }) {
   if (eventState.status === "active") {
-    return { onDutyTime, activeTime: activeTime + timeElapsed };
+    return { activeTime: activeTime + timeElapsed };
   }
 
-  return { onDutyTime, activeTime };
+  return { activeTime };
 }
 
 function getElaspedTimesEventList(history, times) {
@@ -42,7 +34,6 @@ function getElapsedTimesLastEvent(history, times) {
 
 exports.getElapsedTimes = history => {
   let times = {
-    onDutyTime: 0,
     activeTime: 0
   };
 

--- a/src/frontend/components/Firefighter/index.css
+++ b/src/frontend/components/Firefighter/index.css
@@ -78,6 +78,18 @@
   line-height: $line-height-small;
 }
 
+.piquet {
+  background-color: $color-yellow;
+}
+
+.elac {
+  background-color: $color-roasted-yellow;
+}
+
+.eip {
+  background-color: $color-purple;
+}
+
 .status {
   background-color: #161925;
   color: white;

--- a/src/frontend/components/Firefighter/index.js
+++ b/src/frontend/components/Firefighter/index.js
@@ -6,7 +6,10 @@ import "./index.css";
 const label = {
   active: "Disponível",
   inactive: "",
-  busy: "Serviço"
+  busy: "Serviço",
+  piquet: "Piquete",
+  elac: "ELAC",
+  eip: "EIP"
 };
 
 class Firefighter extends PureComponent {
@@ -37,9 +40,16 @@ class Firefighter extends PureComponent {
   };
 
   handleDutyChange = () => {
-    const { updateFirefighterDuty, id, isOnDuty } = this.props;
+    const { id, dutyType: currentDuty, updateFirefighterDuty } = this.props;
 
-    return updateFirefighterDuty(id, !isOnDuty);
+    const nextDuty = {
+      none: "piquet",
+      piquet: "elac",
+      elac: "eip",
+      eip: "none"
+    };
+
+    return updateFirefighterDuty(id, nextDuty[currentDuty]);
   };
 
   handleFirefighterClick = evt => {
@@ -51,7 +61,7 @@ class Firefighter extends PureComponent {
   };
 
   render() {
-    const { id, name, status, isOnDuty } = this.props;
+    const { id, name, status, dutyType } = this.props;
 
     return (
       <button
@@ -62,7 +72,9 @@ class Firefighter extends PureComponent {
         onMouseDown={this.handleFirefighterClick}
       >
         <div styleName="block name">{name}</div>
-        {isOnDuty ? <div styleName="block duty">Piquete</div> : null}
+        {dutyType !== "none" ? (
+          <div styleName={`block duty ${dutyType}`}>{label[dutyType]}</div>
+        ) : null}
         <div styleName="block status">{label[status]}</div>
       </button>
     );
@@ -73,7 +85,7 @@ Firefighter.propTypes = {
   id: PropTypes.string.isRequired,
   name: PropTypes.string.isRequired,
   status: PropTypes.string.isRequired,
-  isOnDuty: PropTypes.bool.isRequired,
+  dutyType: PropTypes.string.isRequired,
   addActiveFirefighter: PropTypes.func.isRequired,
   removeActiveFirefighter: PropTypes.func.isRequired,
   addBusyFirefighter: PropTypes.func.isRequired,

--- a/src/frontend/components/FirefightersList/index.js
+++ b/src/frontend/components/FirefightersList/index.js
@@ -24,8 +24,8 @@ class FirefightersList extends Component {
     const {
       addActiveFirefighter,
       addBusyFirefighter,
-      firefighters,
       removeActiveFirefighter,
+      firefighters,
       updateFirefighterDuty
     } = this.props;
 
@@ -45,7 +45,7 @@ class FirefightersList extends Component {
             />
           ))}
         </div>
-        <Summary {...this.props} />
+        <Summary firefighters={firefighters} />
       </Fragment>
     );
   }

--- a/src/frontend/components/Summary/index.css
+++ b/src/frontend/components/Summary/index.css
@@ -30,11 +30,25 @@
   margin-bottom: 24px;
 }
 
-.duty {
+.piquet {
   width: 100%;
   margin-bottom: 12px;
 
   border-bottom: 4px solid $color-yellow;
+}
+
+.elac {
+  width: 100%;
+  margin-bottom: 12px;
+
+  border-bottom: 4px solid $color-roasted-yellow;
+}
+
+.eip {
+  width: 100%;
+  margin-bottom: 12px;
+
+  border-bottom: 4px solid $color-purple;
 }
 
 .busy {
@@ -57,7 +71,7 @@
 
 .empty {
   content: '';
-  
+
   width: 1px;
   height: $line-height-large;
 

--- a/src/frontend/components/Summary/index.js
+++ b/src/frontend/components/Summary/index.js
@@ -26,7 +26,7 @@ class Summary extends Component {
 
   getBusy = () => _.filter(this.getfirefightersData(), { status: "busy" });
 
-  getOnDuty = () => _.filter(this.getfirefightersData(), { isOnDuty: true });
+  getOnDuty = type => _.filter(this.getfirefightersData(), { dutyType: type });
 
   renderName = firefighter => (
     <span styleName="name" key={firefighter.name}>
@@ -44,35 +44,57 @@ class Summary extends Component {
 
     const active = getActive();
     const busy = getBusy();
-    const onDuty = getOnDuty();
+    const piquet = getOnDuty("piquet");
+    const eip = getOnDuty("eip");
+    const elac = getOnDuty("elac");
 
     return (
       <div styleName="root">
         <div styleName="block">
-          <p styleName="duty">Piquete</p>
-          {!_.isEmpty(onDuty) ? (
+          <div styleName="block">
+            <p styleName="active">Disponível</p>
+            {!_.isEmpty(active) ? (
+              <div styleName="names">
+                {active.map(firefighter => this.renderName(firefighter))}
+              </div>
+            ) : (
+              this.renderEmptyState()
+            )}
+          </div>
+          <div styleName="block">
+            <p styleName="busy">Serviço</p>
+            {!_.isEmpty(busy) ? (
+              <div styleName="names">
+                {busy.map(firefighter => this.renderName(firefighter))}
+              </div>
+            ) : (
+              this.renderEmptyState()
+            )}
+          </div>
+          <p styleName="piquet">Piquete</p>
+          {!_.isEmpty(piquet) ? (
             <div styleName="names">
-              {onDuty.map(firefighter => this.renderName(firefighter))}
+              {piquet.map(firefighter => this.renderName(firefighter))}
             </div>
           ) : (
             this.renderEmptyState()
           )}
         </div>
         <div styleName="block">
-          <p styleName="busy">Serviço</p>
-          {!_.isEmpty(busy) ? (
+          <p styleName="elac">ELAC</p>
+          {!_.isEmpty(elac) ? (
             <div styleName="names">
-              {busy.map(firefighter => this.renderName(firefighter))}
+              {elac.map(firefighter => this.renderName(firefighter))}
             </div>
           ) : (
             this.renderEmptyState()
           )}
         </div>
         <div styleName="block">
-          <p styleName="active">Ativo</p>
-          {!_.isEmpty(active) ? (
+          <p styleName="eip">EIP</p>
+          {!_.isEmpty(eip) ? (
             <div styleName="names">
-              {active.map(firefighter => this.renderName(firefighter))}{" "}
+              {eip.map(firefighter => this.renderName(firefighter))}
             </div>
           ) : (
             this.renderEmptyState()

--- a/src/frontend/containers/withFirefighters/index.js
+++ b/src/frontend/containers/withFirefighters/index.js
@@ -54,10 +54,10 @@ export default ChildComponent =>
       });
     };
 
-    updateFirefighterDuty = async (id, isOnDuty) => {
+    updateFirefighterDuty = async (id, dutyType) => {
       this.socket.emit("update_firefighter", {
         id,
-        payload: { isOnDuty }
+        payload: { dutyType }
       });
     };
 

--- a/src/frontend/styles/colors.css
+++ b/src/frontend/styles/colors.css
@@ -1,6 +1,8 @@
 $color-yellow: #f1d302;
+$color-roasted-yellow: #F1A302;
 $color-fire-red: #f03434;
 $color-grey: #e3e3e3;
 $color-leaf-green: #00a878;
 $color-black: #161925;
 $color-blue: #7eb2dd;
+$color-purple: #7586FE;


### PR DESCRIPTION
Why:

  - Situation has evolved and now besides the normal piquet, there are 2 
more teams which belong to a distinct category: elac, and eip.

This change addresses the need by:

  - Updating dashboard accordingly
  - Removing duty from the time calculation events
<img width="1663" alt="Screenshot 2019-07-06 at 15 26 35" src="https://user-images.githubusercontent.com/26875009/60757514-bd225280-a003-11e9-940e-dcdb490babc0.png">
