### PR TITLE
Enforce admin-only access to API resources

### DIFF
--- a/src/backend/models/firefighter.js
+++ b/src/backend/models/firefighter.js
@@ -7,7 +7,8 @@ const FirefighterSchema = new mongoose.Schema(
     code: { type: String, unique: true, index: true },
     password: { type: String },
     status: String,
-    dutyType: String
+    dutyType: String,
+    role: { type: String, enum: ["regular", "admin"], default: "regular" }
   },
   { timestamps: true }
 );

--- a/src/backend/test/server.test.js
+++ b/src/backend/test/server.test.js
@@ -22,7 +22,7 @@ describe("Firefighters HTTP API", () => {
   });
 
   beforeEach(async () => {
-    user = await firefightersFactory.create();
+    user = await firefightersFactory.create({ role: "admin" });
 
     token = auth.firefighterToToken(user);
   });
@@ -41,7 +41,7 @@ describe("Firefighters HTTP API", () => {
 
     const response = await chai
       .request(server)
-      .post("/api/firefighters")
+      .post("/api/admin/firefighters")
       .send(userParams);
 
     expect(response.status).to.eq(401);
@@ -52,7 +52,7 @@ describe("Firefighters HTTP API", () => {
 
     const response = await chai
       .request(server)
-      .post("/api/firefighters")
+      .post("/api/admin/firefighters")
       .set("Authorization", token)
       .send(userParams);
 
@@ -101,7 +101,7 @@ describe("Firefighters HTTP API", () => {
 
     const response = await chai
       .request(server)
-      .get("/api/firefighters")
+      .get("/api/admin/firefighters")
       .set("Authorization", token);
 
     expect(response.body).to.be.eql(firefighters);
@@ -115,7 +115,7 @@ describe("Firefighters HTTP API", () => {
 
     const response = await chai
       .request(server)
-      .put(`/api/firefighters/${firefighters[2].id}`)
+      .put(`/api/admin/firefighters/${firefighters[2].id}`)
       .set("Authorization", token)
       .send({ status: "active" });
 
@@ -135,7 +135,7 @@ describe("Firefighters HTTP API", () => {
 
     const response = await chai
       .request(server)
-      .put(`/api/firefighters/${firefighters[2].id}`)
+      .put(`/api/admin/firefighters/${firefighters[2].id}`)
       .set("Authorization", token)
       .send({ status: "inactive" });
 

--- a/src/backend/test/server.test.js
+++ b/src/backend/test/server.test.js
@@ -12,19 +12,17 @@ const app = server.listen(3001);
 
 chai.use(chaiHttp);
 
-describe("Firefighters HTTP API", () => {
-  let token;
-  let user;
+async function createUserAndToken(options) {
+  const user = await firefightersFactory.create(options);
+  const token = auth.firefighterToToken(user);
 
+  return { user, token };
+}
+
+describe("Firefighters HTTP API", () => {
   before(async () => {
     await connect();
     await mongoose.connection.db.dropDatabase();
-  });
-
-  beforeEach(async () => {
-    user = await firefightersFactory.create({ role: "admin" });
-
-    token = auth.firefighterToToken(user);
   });
 
   after(async () => {
@@ -36,110 +34,167 @@ describe("Firefighters HTTP API", () => {
     await mongoose.connection.db.dropDatabase();
   });
 
-  it("requests without token return an unhauthorized response", async () => {
-    const userParams = firefightersFactory.build();
+  describe("POST /api/auth", () => {
+    it("should authenticate an user with a correct password", async () => {
+      const firefighter = await firefightersFactory.create();
 
-    const response = await chai
-      .request(server)
-      .post("/api/admin/firefighters")
-      .send(userParams);
+      const response = await chai
+        .request(server)
+        .post("/api/auth")
+        .send({
+          code: firefighter.code,
+          password: "foobar"
+        });
+      const firefighterFromToken = await auth.tokenToFirefighter(
+        response.body.jwt
+      );
 
-    expect(response.status).to.eq(401);
-  });
-
-  it("should create a user", async () => {
-    const userParams = firefightersFactory.build();
-
-    const response = await chai
-      .request(server)
-      .post("/api/admin/firefighters")
-      .set("Authorization", token)
-      .send(userParams);
-
-    expect(response.body.code).to.eq(userParams.code);
-    expect(response.body.password).to.not.exist;
-  });
-
-  it("should authenticate an user with a correct password", async () => {
-    const firefighter = await firefightersFactory.create();
-
-    const response = await chai
-      .request(server)
-      .post("/api/firefighters/auth")
-      .send({
-        code: firefighter.code,
-        password: "foobar"
-      });
-    const firefighterFromToken = await auth.tokenToFirefighter(
-      response.body.jwt
-    );
-
-    expect(response.body.code).to.eq(firefighter.code);
-    expect(firefighterFromToken.code).to.eq(firefighter.code);
-  });
-
-  it("should not authenticate an user with a incorrect password", async () => {
-    const firefighter = await firefightersFactory.create();
-
-    const response = await chai
-      .request(server)
-      .post("/api/firefighters/auth")
-      .set("Authorization", token)
-      .send({
-        code: firefighter.code,
-        password: "badpassword"
-      });
-
-    expect(response.status).to.eq(404);
-  });
-
-  it("should return firefighters", async () => {
-    const firefighters = serialize([
-      user,
-      ...(await firefightersFactory.createList(3))
-    ]);
-
-    const response = await chai
-      .request(server)
-      .get("/api/admin/firefighters")
-      .set("Authorization", token);
-
-    expect(response.body).to.be.eql(firefighters);
-  });
-
-  it("should set firefighter number 2 to active", async () => {
-    const firefighters = serialize([
-      user,
-      ...(await firefightersFactory.createList(3))
-    ]);
-
-    const response = await chai
-      .request(server)
-      .put(`/api/admin/firefighters/${firefighters[2].id}`)
-      .set("Authorization", token)
-      .send({ status: "active" });
-
-    expect(response.body[2].name).to.eq(firefighters[2].name);
-    expect(response.body[2].status).to.eq("active");
-  });
-
-  it("should set firefighter number 3 to inactive", async () => {
-    const firefighters = serialize([
-      user,
-      ...(await firefightersFactory.createList(3))
-    ]);
-
-    await firefightersApi.updateFirefighter(firefighters[2].id, {
-      status: "active"
+      expect(response.body.code).to.eq(firefighter.code);
+      expect(firefighterFromToken.code).to.eq(firefighter.code);
     });
 
-    const response = await chai
-      .request(server)
-      .put(`/api/admin/firefighters/${firefighters[2].id}`)
-      .set("Authorization", token)
-      .send({ status: "inactive" });
+    it("should not authenticate an user with a incorrect password", async () => {
+      const { token } = await createUserAndToken({ role: "admin" });
+      const firefighter = await firefightersFactory.create();
 
-    expect(response.body[2].name).to.eq(firefighters[2].name);
-    expect(response.body[2].status).to.eq("inactive");
+      const response = await chai
+        .request(server)
+        .post("/api/uth")
+        .set("Authorization", token)
+        .send({
+          code: firefighter.code,
+          password: "badpassword"
+        });
+
+      expect(response.status).to.eq(404);
+    });
+  });
+
+  describe("POST /api/admin/firefighters", () => {
+    it("requests without token return an unhauthorized response", async () => {
+      const userParams = firefightersFactory.build();
+
+      const response = await chai
+        .request(server)
+        .post("/api/admin/firefighters")
+        .send(userParams);
+
+      expect(response.status).to.eq(401);
+    });
+
+    it("requests from non-admin return an unhauthorized response", async () => {
+      const { token } = await createUserAndToken();
+      const userParams = firefightersFactory.build();
+
+      const response = await chai
+        .request(server)
+        .post("/api/admin/firefighters")
+        .set("Authorization", token)
+        .send(userParams);
+
+      expect(response.status).to.eq(401);
+    });
+
+    it("should create a user", async () => {
+      const { token } = await createUserAndToken({ role: "admin" });
+      const userParams = firefightersFactory.build();
+
+      const response = await chai
+        .request(server)
+        .post("/api/admin/firefighters")
+        .set("Authorization", token)
+        .send(userParams);
+
+      expect(response.body.code).to.eq(userParams.code);
+      expect(response.body.password).to.not.exist;
+    });
+  });
+
+  describe("GET /api/admin/firefighters", () => {
+    it("requests without token return an unhauthorized response", async () => {
+      const userParams = firefightersFactory.build();
+
+      const response = await chai
+        .request(server)
+        .get("/api/admin/firefighters")
+        .send(userParams);
+
+      expect(response.status).to.eq(401);
+    });
+
+    it("requests from non-admin return an unhauthorized response", async () => {
+      const { token } = await createUserAndToken();
+      const userParams = firefightersFactory.build();
+
+      const response = await chai
+        .request(server)
+        .get("/api/admin/firefighters")
+        .set("Authorization", token)
+        .send(userParams);
+
+      expect(response.status).to.eq(401);
+    });
+
+    it("should return firefighters", async () => {
+      const { user, token } = await createUserAndToken({ role: "admin" });
+      const firefighters = serialize([
+        user,
+        ...(await firefightersFactory.createList(3))
+      ]);
+
+      const response = await chai
+        .request(server)
+        .get("/api/admin/firefighters")
+        .set("Authorization", token);
+
+      expect(response.body).to.be.eql(firefighters);
+    });
+  });
+
+  describe("PUT /api/admin/firefighters/:id", () => {
+    it("requests without token return an unhauthorized response", async () => {
+      const userParams = firefightersFactory.build();
+
+      const response = await chai
+        .request(server)
+        .put("/api/admin/firefighters")
+        .send(userParams);
+
+      expect(response.status).to.eq(401);
+    });
+
+    it("requests from non-admin return an unhauthorized response", async () => {
+      const { token } = await createUserAndToken();
+      const userParams = firefightersFactory.build();
+
+      const response = await chai
+        .request(server)
+        .put("/api/admin/firefighters")
+        .set("Authorization", token)
+        .send(userParams);
+
+      expect(response.status).to.eq(401);
+    });
+
+    it("should update firefighters", async () => {
+      const { user, token } = await createUserAndToken({ role: "admin" });
+      const firefighters = serialize([
+        user,
+        ...(await firefightersFactory.createList(3))
+      ]);
+
+      await firefightersApi.updateFirefighter(firefighters[2].id, {
+        status: "active"
+      });
+
+      const response = await chai
+        .request(server)
+        .put(`/api/admin/firefighters/${firefighters[2].id}`)
+        .set("Authorization", token)
+        .send({ status: "inactive" });
+
+      expect(response.body[2].name).to.eq(firefighters[2].name);
+      expect(response.body[2].status).to.eq("inactive");
+    });
   });
 });

--- a/src/backend/web/auth.js
+++ b/src/backend/web/auth.js
@@ -69,11 +69,27 @@ const requireAuth = async (req, res, next) => {
   next();
 };
 
+const requireAdminAuth = async (req, res, next) => {
+  const authorizationHeader = req.get("Authorization");
+  const firefighter = await tokenToFirefighter(authorizationHeader);
+
+  if (!firefighter || firefighter.role !== "admin") {
+    res.sendStatus(401);
+
+    return;
+  }
+
+  req.currentUser = firefighter;
+
+  next();
+};
+
 module.exports = {
   basicAuth,
   ensureBasicAuthCredentials,
   ensureJwtKey,
   firefighterToToken,
   tokenToFirefighter,
-  requireAuth
+  requireAuth,
+  requireAdminAuth
 };

--- a/src/backend/web/server.js
+++ b/src/backend/web/server.js
@@ -72,27 +72,26 @@ app.post("/api/firefighters/auth", async (req, res) => {
   }
 });
 
+app.use(auth.requireAdminAuth);
 // Everything below this requires AUTH
 
-app.use(auth.requireAuth);
-
-app.get("/api/firefighters", async (req, res) => {
+app.get("/api/admin/firefighters", async (req, res) => {
   res.send(await firefighters.getFirefighters());
 });
 
-app.post("/api/firefighters", async (req, res) => {
+app.post("/api/admin/firefighters", async (req, res) => {
   const { name, code, password } = req.body;
 
   res.send(await firefighters.createFirefighter({ name, code, password }));
 });
 
-app.put("/api/firefighters/:id", async (req, res) => {
+app.put("/api/admin/firefighters/:id", async (req, res) => {
   const firefighterId = req.params.id;
 
   res.send(await firefighters.updateFirefighter(firefighterId, req.body));
 });
 
-app.get("/api/firefighters/:id/history", async (req, res) => {
+app.get("/api/admin/firefighters/:id/history", async (req, res) => {
   const firefighterId = req.params.id;
 
   res.send(await firefightersHistory.getHistoryOfFirefighter(firefighterId));

--- a/src/backend/web/server.js
+++ b/src/backend/web/server.js
@@ -52,7 +52,7 @@ app.get("/ping", async (req, res) => {
   res.status(200).send();
 });
 
-app.post("/api/firefighters/auth", async (req, res) => {
+app.post("/api/auth", async (req, res) => {
   const { code, password } = req.body;
 
   const firefighter = await firefighters.authenticateFirefighter(


### PR DESCRIPTION
Also rename routes to use `/api/admin` except the login route. All resources under admin need a admin user.